### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+indent_style = tab
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # data
 *.csv
+
+# python
+*.pyc

--- a/better_budget.py
+++ b/better_budget.py
@@ -7,7 +7,7 @@ def reading():
 	df = temp.loc[(temp["Category"] == 'DEBIT')]
 
 	total = np.sum(df["Amount"])
-	print('You have spent ${:.2f} this month.'.format(abs(total)))
+	print('You have spent ${:.2f} this month.' . format(abs(total)))
 
 	return df, abs(total)
 
@@ -19,16 +19,16 @@ def get_categories(dataframe, keywords):
 	return sub_dfs
 
 def compare_budget(dataframes, budget, total):
-	total_spent=0
+	total_spent = 0
 	for key in budget:
 		spent = np.abs(sub_dfs[key]['Amount'].sum())
 		saved = budget[key] - spent
 		total_spent += abs(spent)
 		if saved > 0:
-			print('Of your {} budget, you have spent ${:.2f}, and saved ${:.2f}.'.format(key, spent, saved))
+			print('Of your {} budget, you have spent ${:.2f}, and saved ${:.2f}.' . format(key, spent, saved))
 		else: 
-			print('Oops! In your {} budget, you have spent ${:.2f}, which is ${:.2f} over budget.'.format(key, spent, abs(saved)))
-	print('there is {} unaccounted for.'.format(total-total_spent))
+			print('Oops! In your {} budget, you have spent ${:.2f}, which is ${:.2f} over budget.' . format(key, spent, abs(saved)))
+	print('there is {} unaccounted for.' . format(total - total_spent))
 
 def plot_budget(dataframes, budget_dict):
 	cat_totals = {k: abs(v['Amount'].sum()) for k, v in dataframes.items()}

--- a/better_budget.py
+++ b/better_budget.py
@@ -40,7 +40,7 @@ def plot_budget(dataframes, budget_dict):
 	plt.show()
 
 keywords = {
-	'fun': ['soc', 'puff', 'diner', 'beer'], 
+	'fun': ['soc', 'puff', 'diner', 'beer'],
 	'food': ['tech', 'fresh'],
 	'coffee': ['coffee', 'cafe', 'intelligentsia'],
 	'travel': ['american'],


### PR DESCRIPTION
This is about as far as I can go without sample data.

- `.editorconfig` is mostly so I don't fuck up your formatting
  - If you install the editorconfig plugin on your text editor it will set the formatting declared in the `.editorconfig`. In this case its set to tab size 4 spaces, I assumed that was your preference from looking at the codebase. 

- Added `.pyc` files to the `.gitignore` and a root `__init__.py` in prep for when you break the script into multiple files.

- Some white space and formatting fixes
  - Programming is like English, not all the rules are strict, but a sentence is a lot clearer when you enforce extra rules to help follow a format. It's like how a paragraph doesn't need a topic sentence and a closing sentence, but they sure help add cohesion to the paper. Or you could change the font every word, but you're going to piss a lot of readers off. Programming is the same, but we have to relearn basic structure.
  - Its good to keep spaces between operators since in other situations it can have completely different meanings, and can make it harder to read.
For example, concatenation is `.`, but is also used for function calls. Spaces help distinguish the concatenation of `cat` and `climb` (`cat.climb`) from calling `climb()` on `cat` (`cat.climb()`).